### PR TITLE
Use storyblok-editable

### DIFF
--- a/components/DynamicComponent.js
+++ b/components/DynamicComponent.js
@@ -1,32 +1,26 @@
-import SbEditable from 'storyblok-react'
-import Teaser from './Teaser'
-import Feature from './Feature'
-import Grid from './Grid'
-import FeaturedArticles from './FeaturedArticles'
-import Placeholder from './Placeholder'
+import Teaser from "./Teaser";
+import Feature from "./Feature";
+import Grid from "./Grid";
+import FeaturedArticles from "./FeaturedArticles";
+import Placeholder from "./Placeholder";
 
 // resolve Storyblok components to Next.js components
 const Components = {
-  'teaser': Teaser,
-  'grid': Grid,
-  'feature': Feature,
-  'featured-articles': FeaturedArticles
-}
+  teaser: Teaser,
+  grid: Grid,
+  feature: Feature,
+  "featured-articles": FeaturedArticles,
+};
 
-const DynamicComponent = ({blok}) => {
+const DynamicComponent = ({ blok }) => {
   // check if component is defined above
-  if (typeof Components[blok.component] !== 'undefined') {
-    const Component = Components[blok.component]
+  if (typeof Components[blok.component] !== "undefined") {
+    const Component = Components[blok.component];
     // wrap with SbEditable for visual editing
-    return (
-      <SbEditable content={blok}>
-        <Component blok={blok} />
-      </SbEditable>
-      )
+    return <Component blok={blok} />;
   }
 
-  return <Placeholder componentName={blok.component}/>
-}
+  return <Placeholder componentName={blok.component} />;
+};
 
-export default DynamicComponent
-
+export default DynamicComponent;

--- a/components/Page.js
+++ b/components/Page.js
@@ -1,14 +1,12 @@
-import DynamicComponent from './DynamicComponent'
-import SbEditable from 'storyblok-react'
+import DynamicComponent from "./DynamicComponent";
+import { sbEditable } from "@storyblok/storyblok-editable";
 
-const Page = ({content}) => (
-  <SbEditable content={content}>
-    <main className="py-4">
-      {content.body.map((blok) =>
-        <DynamicComponent blok={blok} key={blok._uid} />
-      )}
-    </main>
-  </SbEditable>
-)
+const Page = ({ content }) => (
+  <main className="py-4" {...sbEditable(content)}>
+    {content.body.map((blok) => (
+      <DynamicComponent blok={blok} key={blok._uid} />
+    ))}
+  </main>
+);
 
-export default Page
+export default Page;

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "start": "next start"
   },
   "dependencies": {
+    "@storyblok/storyblok-editable": "^1.0.0",
     "axios": "^0.20.0",
     "next": "9.5.4",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "storyblok-js-client": "^3.1.0",
-    "storyblok-react": "^0.1.1"
+    "storyblok-js-client": "^3.1.0"
   },
   "devDependencies": {
     "postcss-preset-env": "^6.7.0",


### PR DESCRIPTION
We created a new `storyblok-editable` npm package to use instead of `storyblok-react`:

https://github.com/storyblok/storyblok-editable

Replace the package in the repository.

https://www.notion.so/storyblok/Update-relevant-tutorials-for-storyblok-editable-npm-package-23c7f827c2774e3b8a053715a904150d